### PR TITLE
initStretch不需要设置大小，设置了这个，主UI不能自适应的变大

### DIFF
--- a/python-version/QCandyUi/WindowWithTitleBar.py
+++ b/python-version/QCandyUi/WindowWithTitleBar.py
@@ -92,7 +92,7 @@ class WindowWithTitleBar(QFrame):
         self.m_isWindowMax = False
         self.m_stretchRectState = NO_SELECT
         self.m_isMousePressed = False
-        self.setMinimumSize(self.mainwidget.minimumWidth(), self.mainwidget.minimumHeight() + Titlebar.TITLEBAR_HEIGHT)
+        # self.setMinimumSize(self.mainwidget.minimumWidth(), self.mainwidget.minimumHeight() + Titlebar.TITLEBAR_HEIGHT)
 
     def getTitbar(self):
         return self.m_titlebar


### PR DESCRIPTION
最近用这个库的时候发现这个问题~，就提一下代码了