### PR TITLE
[fix](Titlebar): 修复关闭子窗口时程序退出问题

### DIFF
--- a/python-version/QCandyUi/Titlebar.py
+++ b/python-version/QCandyUi/Titlebar.py
@@ -147,7 +147,7 @@ class Titlebar(QWidget):
                     self.m_pMaximizeButton.setStyleSheet(self.__getButtonImgQss(IMAGE_ROOT + Titlebar.THEME_IMG_DIR + "/", IMG_RESIZE_NORM, IMG_RESIZE_HOVER, IMG_RESIZE_PRESS, IMG_RESIZE_PRESS))
             elif pButton.objectName() == Titlebar.CLOSE_BUTT_NAME:
                 pWindow.close()
-                os._exit(0)
+                # os._exit(0) 将导致点击子窗口关闭时，整个程序关闭
 
     def __updateMaxmize(self):
         pWindow = self.window()


### PR DESCRIPTION
原代码对右上角X按钮的处理有os._exit(0)，如果在子窗口进行点击，将导致整个程序退出。